### PR TITLE
chore(ci): update GitHub Actions runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-20.04"]
+        os: ["ubuntu-22.04"]
     steps:
         - uses: actions/checkout@v4
         - name: Install uv


### PR DESCRIPTION
This pull request updates the Python CI workflow to use a newer version of Ubuntu for testing.

Closes #13 

Environment update:

* [`.github/workflows/python-check.yaml`](diffhunk://#diff-66643ae2ed0dc6605cfbfa5305ab053d24b7214270f1c960cd49bd35870b0e2aL16-R16): Updated the `os` matrix in the workflow strategy to use `ubuntu-22.04` instead of `ubuntu-20.04`.